### PR TITLE
Add CI workflows for each component

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,56 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE: ${{ github.repository }}
+  TAG: unstable
+
+jobs:
+  e2e-tests:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: e2e
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - uses: docker/setup-buildx-action@v3
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
+    - name: Build and export to Docker
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        load: true
+        tags: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.TAG }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        working-directory: .
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: playwright-report
+        path: e2e/playwright-report/
+        retention-days: 30

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -19,6 +19,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   test:
     if: github.event.pull_request.draft == false
@@ -76,3 +80,20 @@ jobs:
         run: go mod download
       - name: Check for issues
         run: go vet ./...
+
+  golangci:
+    if: github.event.pull_request.draft == false
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest
+          working-directory: server

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -5,12 +5,14 @@ on:
     branches:
       - main
     paths:
+      - .github/workflows/**
       - server/**
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
     paths:
+      - .github/workflows/**
       - server/**
 
 concurrency:

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -1,0 +1,73 @@
+name: Server CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - server/**
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
+    paths:
+      - server/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    if: github.event.pull_request.draft == false
+    name: Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22.x'
+      - name: Install dependencies
+        run: go mod download
+      - name: Run tests
+        run: go test -v ./...
+
+  fmt:
+    if: github.event.pull_request.draft == false
+    name: Gofmt
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22.x'
+      - name: Install dependencies
+        run: go mod download
+      - name: Check formatting
+        run: test -z $(gofmt -l .)
+
+  vet:
+    if: github.event.pull_request.draft == false
+    name: Vet
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22.x'
+      - name: Install dependencies
+        run: go mod download
+      - name: Check for issues
+        run: go vet ./...

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.x'
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
       - name: Install dependencies
         run: go mod download
       - name: Run tests
@@ -50,7 +51,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.x'
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
       - name: Install dependencies
         run: go mod download
       - name: Check formatting
@@ -68,7 +70,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.x'
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
       - name: Install dependencies
         run: go mod download
       - name: Check for issues

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - .github/workflows/**
       - server/**
+      - go.*
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
@@ -14,6 +15,7 @@ on:
     paths:
       - .github/workflows/**
       - server/**
+      - go.*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -28,16 +30,13 @@ jobs:
     if: github.event.pull_request.draft == false
     name: Test
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: server
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version-file: server/go.mod
-          cache-dependency-path: server/go.sum
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
       - name: Install dependencies
         run: go mod download
       - name: Run tests
@@ -47,16 +46,13 @@ jobs:
     if: github.event.pull_request.draft == false
     name: Gofmt
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: server
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version-file: server/go.mod
-          cache-dependency-path: server/go.sum
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
       - name: Install dependencies
         run: go mod download
       - name: Check formatting
@@ -66,16 +62,13 @@ jobs:
     if: github.event.pull_request.draft == false
     name: Vet
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: server
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version-file: server/go.mod
-          cache-dependency-path: server/go.sum
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
       - name: Install dependencies
         run: go mod download
       - name: Check for issues
@@ -89,11 +82,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: server/go.mod
-          cache-dependency-path: server/go.sum
+          go-version-file: go.mod
+          cache-dependency-path: go.sum
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
           version: latest
-          working-directory: server

--- a/.github/workflows/unstable.yml
+++ b/.github/workflows/unstable.yml
@@ -1,59 +1,21 @@
 name: Unstable Build
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Server CI", "Web CI", "E2E Tests"]
     branches: [main]
+    types: 
+      - completed
 
 env:
   REGISTRY: ghcr.io
   IMAGE: ${{ github.repository }}
   TAG: unstable
 
-jobs:     
-  test:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: e2e
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: lts/*
-    - uses: docker/setup-buildx-action@v3
-    - name: Extract metadata (tags, labels) for Docker
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE }}
-    - name: Build and export to Docker
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        load: true
-        tags: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.TAG }}
-        labels: ${{ steps.meta.outputs.labels }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        working-directory: .
-    - name: Install dependencies
-      run: npm ci
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
-    - name: Run Playwright tests
-      run: npx playwright test
-    - uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: playwright-report
-        path: e2e/playwright-report/
-        retention-days: 30
-
+jobs:
   push:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    needs: test
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -1,0 +1,107 @@
+name: Web CI
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - web/**
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
+    paths:
+      - web/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  check:
+    if: github.event.pull_request.draft == false
+    name: Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: web
+      - run: cargo check --all --tests --all-features --all-targets
+
+  test:
+    if: github.event.pull_request.draft == false
+    name: Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: web
+      - uses: davidB/rust-cargo-make@v1
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with: # speed things up a bit
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+      - run: cargo test --all --all-features --all-targets
+
+  fmt:
+    if: github.event.pull_request.draft == false
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt            
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: web
+      - uses: cargo-bins/cargo-binstall@v1.6.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo binstall -y dioxus-cli@0.5.4
+      - run: cargo fmt --all -- --check
+      - run: dx fmt --check
+
+  clippy:
+    if: github.event.pull_request.draft == false
+    name: Clippy
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: web
+      - run: cargo clippy --workspace --tests --all-features --all-targets -- -D warnings

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -5,12 +5,14 @@ on:
     branches:
       - main
     paths:
+      - .github/workflows/**
       - web/**
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
     paths:
+      - .github/workflows/**
       - web/**
 
 concurrency:

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,7 @@
             '';
 
             packages = with pkgs; [
-              # Web
+              act
               air
               dioxus-cli
               just


### PR DESCRIPTION
For every push on `main`,  tests and linters are run on both the server and the web application. E2E tests are also run while prebuilding the `oxidrive:unstable` Docker image.

```mermaid
flowchart LR
  e2e[E2E Tests] --> unstable[Unstable Build]
  server[Server CI] --> unstable
  web[Web CI] --> unstable
  unstable --> done{{ghcr.io/oxidrive/oxidrive:unstable}}
  style done stroke: #238636
```

Additionally, when a non-draft PR targeting `main` is opened the `Server CI` and `Web CI` workflows are run to verify that the code changes are sound.


```mermaid
flowchart LR
  server[Server CI] --> done{PR Ready}
  web[Web CI] --> done
  style done stroke: #238636
```