### PR TITLE
Filesystem optional dependency for integration tests

### DIFF
--- a/server/internal/testutil/filesystem.go
+++ b/server/internal/testutil/filesystem.go
@@ -1,0 +1,29 @@
+package testutil
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+// FileSystemContainerConfig holds all configs for the temp filesystem that can be used as a dependency for integration tests
+type FileSystemContainerConfig struct {
+	Path string // Path where the temporary directory is created. Note that it will be deleted at the end of the test.
+}
+
+// WithFilesystem creates a tempdir using the std testing lib
+func WithFilesystem(cfg FileSystemContainerConfig) func(context.Context, *testing.T) func() {
+	return func(_ context.Context, t *testing.T) func() {
+		t.Helper()
+
+		if err := os.MkdirAll(cfg.Path, 0750); err != nil {
+			t.Fatal(err)
+		}
+
+		return func() {
+			if err := os.RemoveAll(cfg.Path); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}

--- a/server/internal/testutil/filesystem.go
+++ b/server/internal/testutil/filesystem.go
@@ -28,14 +28,14 @@ func WithTempDir() IntegrationDependency {
 type dirKey struct{}
 
 // / TempDirFromContext returns the path to the generated tempdir
-func TempDirFromContext(ctx context.Context) string {
+func TempDirFromContext(ctx context.Context, t *testing.T) string {
 	dir, ok := ctx.Value(dirKey{}).(string)
 	if !ok {
-		panic("failed to cast tempdir from context to string")
+		t.Fatal("failed to cast tempdir from context to string")
 	}
 
 	if dir == "" {
-		panic("tempdir not found in context")
+		t.Fatal("tempdir not found in context")
 	}
 
 	return dir

--- a/server/internal/testutil/filesystem.go
+++ b/server/internal/testutil/filesystem.go
@@ -6,24 +6,37 @@ import (
 	"testing"
 )
 
-// FileSystemContainerConfig holds all configs for the temp filesystem that can be used as a dependency for integration tests
-type FileSystemContainerConfig struct {
-	Path string // Path where the temporary directory is created. Note that it will be deleted at the end of the test.
-}
-
-// WithFilesystem creates a tempdir using the std testing lib
-func WithFilesystem(cfg FileSystemContainerConfig) func(context.Context, *testing.T) func() {
-	return func(_ context.Context, t *testing.T) func() {
+// / WithTempDir creates a tempdir using the std testing lib
+func WithTempDir() IntegrationDependency {
+	return IntegrationDependency(func(ctx context.Context, t *testing.T) (context.Context, func()) {
 		t.Helper()
 
-		if err := os.MkdirAll(cfg.Path, 0750); err != nil {
+		dir, err := os.MkdirTemp("", "")
+		if err != nil {
 			t.Fatal(err)
 		}
 
-		return func() {
-			if err := os.RemoveAll(cfg.Path); err != nil {
+		ctx = context.WithValue(ctx, dirKey{}, dir)
+		return ctx, func() {
+			if err := os.RemoveAll(dir); err != nil {
 				t.Fatal(err)
 			}
 		}
+	})
+}
+
+type dirKey struct{}
+
+// / TempDirFromContext returns the path to the generated tempdir
+func TempDirFromContext(ctx context.Context) string {
+	dir, ok := ctx.Value(dirKey{}).(string)
+	if !ok {
+		panic("failed to cast tempdir from context to string")
 	}
+
+	if dir == "" {
+		panic("tempdir not found in context")
+	}
+
+	return dir
 }

--- a/server/internal/testutil/sqlite.go
+++ b/server/internal/testutil/sqlite.go
@@ -41,14 +41,14 @@ func WithSqliteDB(cfg SqliteDBConfig) IntegrationDependency {
 type sqliteKey struct{}
 
 // / SqliteUrlFromContext returns the database URL for the teemporary SQLite database
-func SqliteUrlFromContext(ctx context.Context) string {
+func SqliteUrlFromContext(ctx context.Context, t *testing.T) string {
 	dir, ok := ctx.Value(sqliteKey{}).(string)
 	if !ok {
-		panic("failed to cast SQLite database URL from context to string")
+		t.Fatal("failed to cast SQLite database URL from context to string")
 	}
 
 	if dir == "" {
-		panic("SQLite database URL not found in context")
+		t.Fatal("SQLite database URL not found in context")
 	}
 
 	return dir

--- a/server/internal/testutil/sqlite.go
+++ b/server/internal/testutil/sqlite.go
@@ -1,0 +1,55 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+)
+
+type SqliteDBConfig struct {
+	DbName   string
+	DbParams string
+}
+
+// / WithSqliteDB creates a temporary SQLite database
+func WithSqliteDB(cfg SqliteDBConfig) IntegrationDependency {
+	return IntegrationDependency(func(ctx context.Context, t *testing.T) (context.Context, func()) {
+		t.Helper()
+
+		dir, err := os.MkdirTemp("", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if cfg.DbName == "" {
+			cfg.DbName = "oxidrive.db"
+		}
+
+		url := fmt.Sprintf("sqlite://%s?%s", path.Join(dir, cfg.DbName), cfg.DbParams)
+
+		ctx = context.WithValue(ctx, sqliteKey{}, url)
+		return ctx, func() {
+			if err := os.RemoveAll(dir); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+}
+
+type sqliteKey struct{}
+
+// / SqliteUrlFromContext returns the database URL for the teemporary SQLite database
+func SqliteUrlFromContext(ctx context.Context) string {
+	dir, ok := ctx.Value(sqliteKey{}).(string)
+	if !ok {
+		panic("failed to cast SQLite database URL from context to string")
+	}
+
+	if dir == "" {
+		panic("SQLite database URL not found in context")
+	}
+
+	return dir
+}


### PR DESCRIPTION
What does this PR do?
---

- Add optional dependency for integration tests (first step for an internal testing framework).

Motivation
---
We want a plug-and-play modular system that allows us to inject external dependencies during integration tests.

How to use it
---
```go
func Test_myTest(t *testing.T) {
	ctx, done := testutil.IntegrationTest(
             context.Background(),
             t,
             testutil.WithTempDir(),
             testutil.WithSqliteDB(testutil.SqliteDBConfig{}),
        )
	defer done()
	
	tmpdir := testutil.TempDirFromContext(ctx, t)
	sqliteUrl := testutil.SqliteUrlFromContext(ctx, t)
}
```