### PR TITLE
Token Cleanup Job

### DIFF
--- a/server/Justfile
+++ b/server/Justfile
@@ -3,10 +3,10 @@ set dotenv-load
 build: generate
     go build -o ./bin/oxidrive ./cmd/oxidrive/
 
-run *args: generate fmt
+run *args: generate
     go run ./cmd/oxidrive {{ args }}
 
-test path="./...": generate
+test path="./...":
     @if command -v gotestsum &> /dev/null; then \
       gotestsum --format gotestdox {{ path }}; \
     fi
@@ -14,12 +14,13 @@ test path="./...": generate
       gotestdox {{ path }}; \
     fi
 
-    cd .. && gremlins run ./server/internal --test-cpu=2 --workers=2
+test-mutations:
+    cd .. && INTEGRATION_TEST=1 gremlins run ./server/internal --test-cpu=2 --workers=2
 
 test-integration *args:
     INTEGRATION_TEST=1 just test {{ args }}
 
-watch: fmt
+watch:
     air
 
 generate: openapi

--- a/server/Justfile
+++ b/server/Justfile
@@ -35,7 +35,7 @@ fmt:
     go fmt ./...
 
 psql:
-    @PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER $POSTGRES_DB
+    @PGPASSWORD=${POSTGRES_PASSWORD:-oxidrive} psql -h ${POSTGRES_HOST:-localhost} -p ${POSTGRES_PORT:-5432} -U ${POSTGRES_USER:-oxidrive} ${POSTGRES_DB:-oxidrive}
 
 migration-create name:
     @for db in "postgres" "sqlite"; do \

--- a/server/cmd/oxidrive/jobs.go
+++ b/server/cmd/oxidrive/jobs.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/oxidrive/oxidrive/server/internal/app"
+	"github.com/oxidrive/oxidrive/server/internal/auth"
+	"github.com/oxidrive/oxidrive/server/internal/worker"
+)
+
+func cron(deps app.ApplicationDependencies) []worker.CronJob {
+	return []worker.CronJob{
+		// every 5 minutes
+		{Cron: "*/5 * * * *", Job: auth.NewTokenCleanupJob(deps.Tokens)},
+	}
+}

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -54,6 +54,6 @@ func (app *Application) Users() user.Users {
 	return app.users
 }
 
-func (app *Application) TokenVerifier() *auth.TokenService {
+func (app *Application) Tokens() *auth.TokenService {
 	return &app.tokens
 }

--- a/server/internal/app/app.go
+++ b/server/internal/app/app.go
@@ -1,4 +1,4 @@
-package core
+package app
 
 import (
 	"github.com/oxidrive/oxidrive/server/internal/auth"

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -13,10 +13,10 @@ var (
 
 type Authenticator struct {
 	users  user.Users
-	tokens Tokens
+	tokens TokenService
 }
 
-func NewAuthenticator(users user.Users, tokens Tokens) Authenticator {
+func NewAuthenticator(users user.Users, tokens TokenService) Authenticator {
 	return Authenticator{users: users, tokens: tokens}
 }
 
@@ -39,7 +39,7 @@ func (a *Authenticator) AuthenticateWithPassword(ctx context.Context, username s
 		return nil, nil, ErrAuthenticationFailed
 	}
 
-	t, err := TokenFor(u)
+	t, err := a.tokens.Generate(ctx, u)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/internal/auth/token.go
+++ b/server/internal/auth/token.go
@@ -16,6 +16,10 @@ const oneMonth = 730 * time.Hour
 
 type TokenID string
 
+func (id TokenID) String() string {
+	return string(id)
+}
+
 type Token struct {
 	Value TokenID
 
@@ -74,8 +78,10 @@ func (v *TokenVerifier) VerifyToken(ctx context.Context, token TokenID) error {
 }
 
 type Tokens interface {
+	ExpiringBefore(context.Context, time.Time) ([]Token, error)
 	ByID(context.Context, TokenID) (*Token, error)
 	Store(context.Context, Token) (*Token, error)
+	DeleteAll(context.Context, []Token) error
 }
 
 const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"

--- a/server/internal/auth/token_service.go
+++ b/server/internal/auth/token_service.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/oxidrive/oxidrive/server/internal/core/user"
+)
+
+var ErrInvalidToken = errors.New("invalid token")
+
+type TokenService struct {
+	tokens   Tokens
+	tokenTTL time.Duration
+}
+
+func NewTokenService(tokens Tokens, tokenTTL time.Duration) TokenService {
+	return TokenService{
+		tokens:   tokens,
+		tokenTTL: tokenTTL,
+	}
+}
+
+func (s *TokenService) Generate(ctx context.Context, u *user.User) (*Token, error) {
+	value, err := generate()
+	if err != nil {
+		return nil, err
+	}
+
+	expiresAt := time.Now().Add(s.tokenTTL)
+
+	return &Token{
+		Value:     value,
+		UserID:    u.ID,
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+func (s *TokenService) Verify(ctx context.Context, token TokenID) error {
+	if token == "" || !strings.HasPrefix(string(token), prefix) {
+		return ErrInvalidToken
+	}
+
+	t, err := s.tokens.ByID(ctx, token)
+	if err != nil {
+		return err
+	}
+
+	if t == nil || t.IsExpired() {
+		return ErrInvalidToken
+	}
+
+	return nil
+}
+
+func (s *TokenService) ByID(ctx context.Context, id TokenID) (*Token, error) {
+	return s.tokens.ByID(ctx, id)
+}
+
+func (s *TokenService) Store(ctx context.Context, token Token) (*Token, error) {
+	return s.tokens.Store(ctx, token)
+}

--- a/server/internal/auth/token_test.go
+++ b/server/internal/auth/token_test.go
@@ -23,6 +23,7 @@ func TestTokenVerifier(t *testing.T) {
 		ctx := context.Background()
 
 		tokens := NewTokensMock(t)
+		defer tokens.AssertExpectations(t)
 
 		u := testutil.Must(user.Create("test", "test"))
 		token := testutil.Must(TokenFor(u))
@@ -46,6 +47,7 @@ func TestTokenVerifier(t *testing.T) {
 			ctx := context.Background()
 
 			tokens := NewTokensMock(t)
+			defer tokens.AssertExpectations(t)
 
 			verifier := NewTokenVerifier(tokens)
 
@@ -60,6 +62,7 @@ func TestTokenVerifier(t *testing.T) {
 		ctx := context.Background()
 
 		tokens := NewTokensMock(t)
+		defer tokens.AssertExpectations(t)
 
 		u := testutil.Must(user.Create("test", "test"))
 		token := testutil.Must(TokenFor(u))

--- a/server/internal/auth/tokens_cleanup.go
+++ b/server/internal/auth/tokens_cleanup.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	"context"
+	"time"
+
+	"github.com/oxidrive/oxidrive/server/internal/worker"
+)
+
+var _ worker.Job = (*TokenCleanupJob)(nil)
+
+type TokenCleanupJob struct {
+	tokens Tokens
+}
+
+func NewTokenCleanupJob(tokens Tokens) *TokenCleanupJob {
+	return &TokenCleanupJob{tokens: tokens}
+}
+
+func (*TokenCleanupJob) Name() string {
+	return "auth tokens cleanup"
+}
+
+func (j *TokenCleanupJob) Run(ctx context.Context) error {
+	tt, err := j.tokens.ExpiringBefore(ctx, time.Now())
+	if err != nil {
+		return err
+	}
+
+	if len(tt) == 0 {
+		return nil
+	}
+
+	if err := j.tokens.DeleteAll(ctx, tt); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/server/internal/auth/tokens_cleanup_test.go
+++ b/server/internal/auth/tokens_cleanup_test.go
@@ -1,0 +1,56 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxidrive/oxidrive/server/internal/core/user"
+	"github.com/oxidrive/oxidrive/server/internal/testutil"
+)
+
+func TestTokensCleanupJob(t *testing.T) {
+	t.Run("removes all expired tokens", func(t *testing.T) {
+		ctx := context.Background()
+
+		expired := Token{
+			Value:     "b",
+			UserID:    testutil.Must(user.NewID()),
+			ExpiresAt: time.Now().Add(-1 * time.Hour),
+		}
+
+		tokens := NewTokensMock(t)
+		tokens.On("ExpiringBefore", mock.MatchedBy(isToday)).Return([]Token{expired}, nil).Once()
+		tokens.On("DeleteAll", []Token{expired}).Return(nil).Once()
+		defer tokens.AssertExpectations(t)
+
+		j := NewTokenCleanupJob(tokens)
+
+		err := j.Run(ctx)
+
+		require.NoError(t, err)
+	})
+
+	t.Run("does nothing if no token is expired", func(t *testing.T) {
+		ctx := context.Background()
+
+		tokens := NewTokensMock(t)
+		tokens.On("ExpiringBefore", mock.MatchedBy(isToday)).Return([]Token{}, nil).Once()
+		defer tokens.AssertExpectations(t)
+
+		j := NewTokenCleanupJob(tokens)
+
+		err := j.Run(ctx)
+
+		require.NoError(t, err)
+	})
+}
+
+func isToday(t time.Time) bool {
+	yn, mn, dn := time.Now().Date()
+	y, m, d := t.Date()
+	return y == yn && m == mn && d == dn
+}

--- a/server/internal/auth/tokens_mock.go
+++ b/server/internal/auth/tokens_mock.go
@@ -3,9 +3,12 @@ package auth
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/mock"
 )
+
+var _ Tokens = (*TokensMock)(nil)
 
 type TokensMock struct {
 	mock.Mock
@@ -25,4 +28,14 @@ func (s *TokensMock) ByID(_ context.Context, id TokenID) (*Token, error) {
 func (s *TokensMock) Store(_ context.Context, token Token) (*Token, error) {
 	args := s.Called(token)
 	return args.Get(0).(*Token), args.Error(1)
+}
+
+func (s *TokensMock) ExpiringBefore(_ context.Context, exp time.Time) ([]Token, error) {
+	args := s.Called(exp)
+	return args.Get(0).([]Token), args.Error(1)
+}
+
+func (s *TokensMock) DeleteAll(_ context.Context, tokens []Token) error {
+	args := s.Called(tokens)
+	return args.Error(0)
 }

--- a/server/internal/config/auth.go
+++ b/server/internal/config/auth.go
@@ -1,0 +1,7 @@
+package config
+
+import "time"
+
+type AuthConfig struct {
+	SessionDuration time.Duration `group:"auth" default:"5m" env:"OXIDRIVE_SESSION_DURATION"`
+}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -27,6 +27,8 @@ type Config struct {
 
 	AssetsFolder string `env:"OXIDRIVE_ASSETS_FOLDER" default:"./assets"`
 
+	AuthConfig
+
 	DatabaseConfig
 
 	StorageConfig

--- a/server/internal/core/file/service.go
+++ b/server/internal/core/file/service.go
@@ -18,7 +18,7 @@ type Service struct {
 	files    Files
 }
 
-func InitService(filesContent Contents, filesMetadata Files) Service {
+func NewService(filesContent Contents, filesMetadata Files) Service {
 	return Service{
 		contents: filesContent,
 		files:    filesMetadata,

--- a/server/internal/core/file/service_test.go
+++ b/server/internal/core/file/service_test.go
@@ -21,7 +21,7 @@ func TestService_Upload(t *testing.T) {
 		contentsMock := NewContentsMock(t)
 		filesMock := NewFilesMock(t)
 
-		service := InitService(contentsMock, filesMock)
+		service := NewService(contentsMock, filesMock)
 
 		ctx := context.Background()
 		content := strings.NewReader("")
@@ -47,7 +47,7 @@ func TestService_Upload(t *testing.T) {
 		contentsMock := NewContentsMock(t)
 		filesMock := NewFilesMock(t)
 
-		service := InitService(contentsMock, filesMock)
+		service := NewService(contentsMock, filesMock)
 
 		ctx := context.Background()
 		content := strings.NewReader("")
@@ -72,7 +72,7 @@ func TestService_Upload(t *testing.T) {
 		contentsMock := NewContentsMock(t)
 		filesMock := NewFilesMock(t)
 
-		service := InitService(contentsMock, filesMock)
+		service := NewService(contentsMock, filesMock)
 
 		ctx := context.Background()
 		content := strings.NewReader("")
@@ -98,7 +98,7 @@ func TestService_Upload(t *testing.T) {
 		contentsMock := NewContentsMock(t)
 		filesMock := NewFilesMock(t)
 
-		service := InitService(contentsMock, filesMock)
+		service := NewService(contentsMock, filesMock)
 
 		ctx := context.Background()
 		content := strings.NewReader("")
@@ -126,7 +126,7 @@ func TestService_Upload(t *testing.T) {
 		contentsMock := NewContentsMock(t)
 		filesMock := NewFilesMock(t)
 
-		service := InitService(contentsMock, filesMock)
+		service := NewService(contentsMock, filesMock)
 
 		ctx := context.Background()
 		content := strings.NewReader("")

--- a/server/internal/core/instance/service.go
+++ b/server/internal/core/instance/service.go
@@ -24,7 +24,7 @@ type Service struct {
 	users user.Users
 }
 
-func InitService(info Info, users user.Users) Service {
+func NewService(info Info, users user.Users) Service {
 	return Service{
 		info:  info,
 		users: users,

--- a/server/internal/core/instance/service_test.go
+++ b/server/internal/core/instance/service_test.go
@@ -35,7 +35,7 @@ func TestInstanceService_FirstTimeSetup(t *testing.T) {
 		users.On("Count").Return(0, nil).Twice()
 		users.On("Save", mock.MatchedBy(func(u user.User) bool { return u.Username == created.Username })).Return((*user.User)(nil), nil).Once()
 
-		svc := InitService(info, users)
+		svc := NewService(info, users)
 
 		completed, err := svc.FirstTimeSetupCompleted(ctx)
 		require.NoError(t, err)
@@ -53,7 +53,7 @@ func TestInstanceService_FirstTimeSetup(t *testing.T) {
 		users := user.NewUsersMock(t)
 		users.On("Count").Return(1, nil).Twice()
 
-		svc := InitService(info, users)
+		svc := NewService(info, users)
 
 		initial := InitialAdmin{
 			Username: "test",
@@ -83,7 +83,7 @@ func TestInstanceService_Status(t *testing.T) {
 		users := user.NewUsersMock(t)
 		users.On("Count").Return(1, nil).Twice()
 
-		svc := InitService(info, users)
+		svc := NewService(info, users)
 
 		status, err := svc.Status(ctx)
 		require.NoError(t, err)

--- a/server/internal/infrastructure/auth/tokens_pg.go
+++ b/server/internal/infrastructure/auth/tokens_pg.go
@@ -46,7 +46,7 @@ func (p *PgTokens) Store(ctx context.Context, t auth.Token) (*auth.Token, error)
         $1,
         $2,
         $3
-    )`, t.String(), t.UserID.String(), t.ExpiresAt)
+    )`, t.Value.String(), t.UserID.String(), t.ExpiresAt)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/infrastructure/auth/tokens_pg_test.go
+++ b/server/internal/infrastructure/auth/tokens_pg_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestPgTokens(t *testing.T) {
+	exp := time.Now().Add(1 * time.Hour)
+
 	t.Run("stores and returns a token by ID", func(t *testing.T) {
 		ctx, done := testutil.IntegrationTest(context.Background(), t, testutil.WithPgDB())
 		defer done()
@@ -23,7 +25,7 @@ func TestPgTokens(t *testing.T) {
 		tokens := NewPgTokens(db)
 
 		u := testutil.Must(user.Create("a", "a"))
-		token := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+		token := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.NewToken(u, exp))))
 
 		found, err := tokens.ByID(ctx, token.Value)
 
@@ -42,10 +44,10 @@ func TestPgTokens(t *testing.T) {
 		tokens := NewPgTokens(db)
 
 		u := testutil.Must(user.Create("a", "a"))
-		t1 := testutil.Must(auth.TokenFor(u))
+		t1 := testutil.Must(auth.NewToken(u, exp))
 		t1.ExpiresAt = time.Now().Add(-1 * time.Hour)
 		t1 = testutil.Must(tokens.Store(ctx, *t1))
-		_ = testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+		_ = testutil.Must(tokens.Store(ctx, *testutil.Must(auth.NewToken(u, exp))))
 
 		tt, err := tokens.ExpiringBefore(ctx, time.Now())
 
@@ -63,8 +65,8 @@ func TestPgTokens(t *testing.T) {
 		tokens := NewPgTokens(db)
 
 		u := testutil.Must(user.Create("a", "a"))
-		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
-		t2 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.NewToken(u, exp))))
+		t2 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.NewToken(u, exp))))
 
 		err := tokens.DeleteAll(ctx, []auth.Token{*t1, *t2})
 		require.NoError(t, err)
@@ -87,8 +89,8 @@ func TestPgTokens(t *testing.T) {
 		tokens := NewPgTokens(db)
 
 		u := testutil.Must(user.Create("a", "a"))
-		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
-		t2 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.NewToken(u, exp))))
+		t2 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.NewToken(u, exp))))
 
 		err := tokens.DeleteAll(ctx, []auth.Token{})
 		require.NoError(t, err)

--- a/server/internal/infrastructure/auth/tokens_pg_test.go
+++ b/server/internal/infrastructure/auth/tokens_pg_test.go
@@ -3,8 +3,10 @@ package auth
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/oxidrive/oxidrive/server/internal/auth"
 	"github.com/oxidrive/oxidrive/server/internal/core/user"
@@ -21,12 +23,82 @@ func TestPgTokens(t *testing.T) {
 		tokens := NewPgTokens(db)
 
 		u := testutil.Must(user.Create("a", "a"))
-		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
-		testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+		token := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
 
-		found, err := tokens.ByID(ctx, t1.Value)
+		found, err := tokens.ByID(ctx, token.Value)
 
 		assert.NoError(t, err)
-		assert.Equal(t, t1.Value, found.Value)
+		assert.Equal(t, token.Value, found.Value)
+		assert.Equal(t, token.UserID, found.UserID)
+		assert.Equal(t, token.ExpiresAt.UTC().Truncate(time.Second), found.ExpiresAt.UTC().Truncate(time.Second))
+	})
+
+	t.Run("returns the list of all expiring tokens", func(t *testing.T) {
+		ctx, done := testutil.IntegrationTest(context.Background(), t, testutil.WithPgDB())
+		defer done()
+
+		db := testutil.PgDBFromContext(ctx, t)
+
+		tokens := NewPgTokens(db)
+
+		u := testutil.Must(user.Create("a", "a"))
+		t1 := testutil.Must(auth.TokenFor(u))
+		t1.ExpiresAt = time.Now().Add(-1 * time.Hour)
+		t1 = testutil.Must(tokens.Store(ctx, *t1))
+		_ = testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+
+		tt, err := tokens.ExpiringBefore(ctx, time.Now())
+
+		assert.NoError(t, err)
+		assert.Len(t, tt, 1)
+		assert.Equal(t, t1.Value, tt[0].Value)
+	})
+
+	t.Run("deletes some tokens", func(t *testing.T) {
+		ctx, done := testutil.IntegrationTest(context.Background(), t, testutil.WithPgDB())
+		defer done()
+
+		db := testutil.PgDBFromContext(ctx, t)
+
+		tokens := NewPgTokens(db)
+
+		u := testutil.Must(user.Create("a", "a"))
+		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+		t2 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+
+		err := tokens.DeleteAll(ctx, []auth.Token{*t1, *t2})
+		require.NoError(t, err)
+
+		t1, err = tokens.ByID(ctx, t1.Value)
+		assert.NoError(t, err)
+		assert.Nil(t, t1)
+
+		t2, err = tokens.ByID(ctx, t2.Value)
+		assert.NoError(t, err)
+		assert.Nil(t, t2)
+	})
+
+	t.Run("doesn't delete anything if no tokens are provided", func(t *testing.T) {
+		ctx, done := testutil.IntegrationTest(context.Background(), t, testutil.WithPgDB())
+		defer done()
+
+		db := testutil.PgDBFromContext(ctx, t)
+
+		tokens := NewPgTokens(db)
+
+		u := testutil.Must(user.Create("a", "a"))
+		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+		t2 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+
+		err := tokens.DeleteAll(ctx, []auth.Token{})
+		require.NoError(t, err)
+
+		t1, err = tokens.ByID(ctx, t1.Value)
+		assert.NoError(t, err)
+		assert.NotNil(t, t1)
+
+		t2, err = tokens.ByID(ctx, t2.Value)
+		assert.NoError(t, err)
+		assert.NotNil(t, t2)
 	})
 }

--- a/server/internal/infrastructure/auth/tokens_sqlite.go
+++ b/server/internal/infrastructure/auth/tokens_sqlite.go
@@ -43,7 +43,7 @@ func (p *SqliteTokens) Store(ctx context.Context, t auth.Token) (*auth.Token, er
         $1,
         $2,
         $3
-    )`, t.String(), t.UserID.String(), exp)
+    )`, t.Value.String(), t.UserID.String(), exp)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/infrastructure/auth/tokens_sqlite_test.go
+++ b/server/internal/infrastructure/auth/tokens_sqlite_test.go
@@ -3,8 +3,10 @@ package auth
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/oxidrive/oxidrive/server/internal/auth"
 	"github.com/oxidrive/oxidrive/server/internal/core/user"
@@ -30,5 +32,72 @@ func TestSqliteTokens(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, t1.Value, found.Value)
+		assert.Equal(t, t1.UserID, found.UserID)
+		assert.Equal(t, t1.ExpiresAt.UTC().Truncate(time.Second), found.ExpiresAt.UTC().Truncate(time.Second))
+	})
+
+	t.Run("returns the list of all expiring tokens", func(t *testing.T) {
+		ctx, done := testutil.IntegrationTest(context.Background(), t, testutil.WithSqliteDB(testutil.SqliteDBConfig{}))
+		defer done()
+
+		db := testutil.SqliteDBFromContext(ctx, t)
+
+		tokens := NewSqliteTokens(db)
+
+		u := testutil.Must(user.Create("a", "a"))
+		t1 := testutil.Must(auth.TokenFor(u))
+		t1.ExpiresAt = time.Now().Add(-1 * time.Hour)
+		t1 = testutil.Must(tokens.Store(ctx, *t1))
+		_ = testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+
+		tt, err := tokens.ExpiringBefore(ctx, time.Now())
+
+		assert.NoError(t, err)
+		assert.Len(t, tt, 1)
+		assert.Equal(t, t1.Value, tt[0].Value)
+	})
+
+	t.Run("deletes some tokens", func(t *testing.T) {
+		ctx, done := testutil.IntegrationTest(context.Background(), t, testutil.WithSqliteDB(testutil.SqliteDBConfig{}))
+		defer done()
+
+		db := testutil.SqliteDBFromContext(ctx, t)
+
+		tokens := NewSqliteTokens(db)
+
+		u := testutil.Must(user.Create("a", "a"))
+		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+		_ = testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+
+		err := tokens.DeleteAll(ctx, []auth.Token{*t1})
+		require.NoError(t, err)
+
+		t1, err = tokens.ByID(ctx, t1.Value)
+		assert.NoError(t, err)
+		assert.Nil(t, t1)
+	})
+
+	t.Run("doesn't delete anything if no tokens are provided", func(t *testing.T) {
+		ctx, done := testutil.IntegrationTest(context.Background(), t, testutil.WithSqliteDB(testutil.SqliteDBConfig{}))
+		defer done()
+
+		db := testutil.SqliteDBFromContext(ctx, t)
+
+		tokens := NewSqliteTokens(db)
+
+		u := testutil.Must(user.Create("a", "a"))
+		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+		t2 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+
+		err := tokens.DeleteAll(ctx, []auth.Token{})
+		require.NoError(t, err)
+
+		t1, err = tokens.ByID(ctx, t1.Value)
+		assert.NoError(t, err)
+		assert.NotNil(t, t1)
+
+		t2, err = tokens.ByID(ctx, t2.Value)
+		assert.NoError(t, err)
+		assert.NotNil(t, t2)
 	})
 }

--- a/server/internal/infrastructure/auth/tokens_sqlite_test.go
+++ b/server/internal/infrastructure/auth/tokens_sqlite_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestSqliteTokens(t *testing.T) {
+	exp := time.Now().Add(1 * time.Hour)
+
 	t.Run("stores and returns a token by ID", func(t *testing.T) {
 		t.Parallel()
 
@@ -25,8 +27,8 @@ func TestSqliteTokens(t *testing.T) {
 		tokens := NewSqliteTokens(db)
 
 		u := testutil.Must(user.Create("a", "a"))
-		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
-		testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.NewToken(u, exp))))
+		testutil.Must(tokens.Store(ctx, *testutil.Must(auth.NewToken(u, exp))))
 
 		found, err := tokens.ByID(ctx, t1.Value)
 
@@ -45,10 +47,10 @@ func TestSqliteTokens(t *testing.T) {
 		tokens := NewSqliteTokens(db)
 
 		u := testutil.Must(user.Create("a", "a"))
-		t1 := testutil.Must(auth.TokenFor(u))
+		t1 := testutil.Must(auth.NewToken(u, exp))
 		t1.ExpiresAt = time.Now().Add(-1 * time.Hour)
 		t1 = testutil.Must(tokens.Store(ctx, *t1))
-		_ = testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+		_ = testutil.Must(tokens.Store(ctx, *testutil.Must(auth.NewToken(u, exp))))
 
 		tt, err := tokens.ExpiringBefore(ctx, time.Now())
 
@@ -66,8 +68,8 @@ func TestSqliteTokens(t *testing.T) {
 		tokens := NewSqliteTokens(db)
 
 		u := testutil.Must(user.Create("a", "a"))
-		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
-		_ = testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.NewToken(u, exp))))
+		_ = testutil.Must(tokens.Store(ctx, *testutil.Must(auth.NewToken(u, exp))))
 
 		err := tokens.DeleteAll(ctx, []auth.Token{*t1})
 		require.NoError(t, err)
@@ -86,8 +88,8 @@ func TestSqliteTokens(t *testing.T) {
 		tokens := NewSqliteTokens(db)
 
 		u := testutil.Must(user.Create("a", "a"))
-		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
-		t2 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.TokenFor(u))))
+		t1 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.NewToken(u, exp))))
+		t2 := testutil.Must(tokens.Store(ctx, *testutil.Must(auth.NewToken(u, exp))))
 
 		err := tokens.DeleteAll(ctx, []auth.Token{})
 		require.NoError(t, err)

--- a/server/internal/infrastructure/infrastructure.go
+++ b/server/internal/infrastructure/infrastructure.go
@@ -4,9 +4,9 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/rs/zerolog"
 
+	"github.com/oxidrive/oxidrive/server/internal/app"
 	"github.com/oxidrive/oxidrive/server/internal/auth"
 	"github.com/oxidrive/oxidrive/server/internal/config"
-	"github.com/oxidrive/oxidrive/server/internal/core"
 	"github.com/oxidrive/oxidrive/server/internal/core/file"
 	"github.com/oxidrive/oxidrive/server/internal/core/user"
 	authinfra "github.com/oxidrive/oxidrive/server/internal/infrastructure/auth"
@@ -14,7 +14,7 @@ import (
 	userinfra "github.com/oxidrive/oxidrive/server/internal/infrastructure/user"
 )
 
-func Setup(cfg config.Config, db *sqlx.DB, logger zerolog.Logger) core.ApplicationDependencies {
+func Setup(cfg config.Config, db *sqlx.DB, logger zerolog.Logger) app.ApplicationDependencies {
 	var contents file.Contents
 	var files file.Files
 	var tokens auth.Tokens
@@ -33,7 +33,7 @@ func Setup(cfg config.Config, db *sqlx.DB, logger zerolog.Logger) core.Applicati
 
 	contents = fileinfra.NewContentFS(cfg.StorageConfig, logger)
 
-	return core.ApplicationDependencies{
+	return app.ApplicationDependencies{
 		Contents: contents,
 		Files:    files,
 		Tokens:   tokens,

--- a/server/internal/infrastructure/user/users_pg_test.go
+++ b/server/internal/infrastructure/user/users_pg_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/oxidrive/oxidrive/server/internal/core/user"
 	"github.com/oxidrive/oxidrive/server/internal/testutil"
@@ -24,7 +25,7 @@ func TestPgUsers_Count(t *testing.T) {
 
 		count, err := users.Count(ctx)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 2, count)
 
 	})
@@ -42,7 +43,7 @@ func TestPgUsers_Save(t *testing.T) {
 		users := NewPgUsers(db)
 
 		created, err := users.Save(ctx, *testutil.Must(user.Create(username, "a")))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, username, created.Username)
 
 	})
@@ -58,14 +59,14 @@ func TestPgUsers_Save(t *testing.T) {
 		users := NewPgUsers(db)
 
 		created, err := users.Save(ctx, *testutil.Must(user.Create(username, "a")))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, username, created.Username)
 
 		changedUsername := "changed"
 		created.Username = changedUsername
 
 		updated, err := users.Save(ctx, *created)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, created.ID, updated.ID)
 		assert.Equal(t, changedUsername, updated.Username)
 
@@ -85,7 +86,7 @@ func TestPgUsers_ByID(t *testing.T) {
 
 		found, err := users.ByID(ctx, u.ID)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, u.ID, found.ID)
 		assert.Equal(t, u.Username, found.Username)
 	})
@@ -103,7 +104,7 @@ func TestPgUsers_ByID(t *testing.T) {
 
 		found, err := users.ByID(ctx, id)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Nil(t, found)
 	})
 }
@@ -122,7 +123,7 @@ func TestPgUsers_ByUsername(t *testing.T) {
 
 		found, err := users.ByUsername(ctx, username)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, username, found.Username)
 	})
 
@@ -139,7 +140,7 @@ func TestPgUsers_ByUsername(t *testing.T) {
 
 		found, err := users.ByUsername(ctx, username)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Nil(t, found)
 	})
 }

--- a/server/internal/testutil/sqlite.go
+++ b/server/internal/testutil/sqlite.go
@@ -34,7 +34,6 @@ func WithSqliteDB(cfg SqliteDBConfig) IntegrationDependency {
 		}
 
 		url := fmt.Sprintf("sqlite://%s?%s", path.Join(dir, cfg.DbName), cfg.DbParams)
-		fmt.Println(url)
 
 		ctx = context.WithValue(ctx, sqliteKey{}, url)
 		return ctx, func() {

--- a/server/internal/web/auth.go
+++ b/server/internal/web/auth.go
@@ -51,7 +51,7 @@ func (t tokenAuthenticator) authenticate(ctx context.Context, input *openapi3fil
 		return ErrTokenAuthenticationFailed
 	}
 
-	if err := t.app.TokenVerifier().Verify(ctx, auth.TokenID(token)); err != nil {
+	if err := t.app.Tokens().Verify(ctx, auth.TokenID(token)); err != nil {
 		t.logger.Debug().Err(err).Msg("token authentication failed")
 		return ErrTokenAuthenticationFailed
 	}

--- a/server/internal/web/auth.go
+++ b/server/internal/web/auth.go
@@ -51,8 +51,8 @@ func (t tokenAuthenticator) authenticate(ctx context.Context, input *openapi3fil
 		return ErrTokenAuthenticationFailed
 	}
 
-	if err := t.app.TokenVerifier().VerifyToken(ctx, auth.TokenID(token)); err != nil {
-		t.logger.Warn().Err(err).Msg("token authentication failed")
+	if err := t.app.TokenVerifier().Verify(ctx, auth.TokenID(token)); err != nil {
+		t.logger.Debug().Err(err).Msg("token authentication failed")
 		return ErrTokenAuthenticationFailed
 	}
 

--- a/server/internal/web/auth.go
+++ b/server/internal/web/auth.go
@@ -11,15 +11,15 @@ import (
 	"github.com/go-http-utils/headers"
 	"github.com/rs/zerolog"
 
+	"github.com/oxidrive/oxidrive/server/internal/app"
 	"github.com/oxidrive/oxidrive/server/internal/auth"
-	"github.com/oxidrive/oxidrive/server/internal/core"
 )
 
 var (
 	ErrTokenAuthenticationFailed = errors.New("token authentication failed")
 )
 
-func authenticate(logger zerolog.Logger, app *core.Application) openapi3filter.AuthenticationFunc {
+func authenticate(logger zerolog.Logger, app *app.Application) openapi3filter.AuthenticationFunc {
 	return func(ctx context.Context, input *openapi3filter.AuthenticationInput) error {
 		var auth authenticator
 		switch input.SecuritySchemeName {
@@ -42,7 +42,7 @@ type authenticator interface {
 
 type tokenAuthenticator struct {
 	logger zerolog.Logger
-	app    *core.Application
+	app    *app.Application
 }
 
 func (t tokenAuthenticator) authenticate(ctx context.Context, input *openapi3filter.AuthenticationInput) error {

--- a/server/internal/web/handler/files.go
+++ b/server/internal/web/handler/files.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/rs/zerolog"
 
-	"github.com/oxidrive/oxidrive/server/internal/core"
+	"github.com/oxidrive/oxidrive/server/internal/app"
 	"github.com/oxidrive/oxidrive/server/internal/core/file"
 	"github.com/oxidrive/oxidrive/server/internal/web/api"
 )
 
 type Files struct {
 	Logger             zerolog.Logger
-	App                *core.Application
+	App                *app.Application
 	MultipartMaxMemory int64
 }
 

--- a/server/internal/web/handler/instance.go
+++ b/server/internal/web/handler/instance.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/rs/zerolog"
 
-	"github.com/oxidrive/oxidrive/server/internal/core"
+	"github.com/oxidrive/oxidrive/server/internal/app"
 	"github.com/oxidrive/oxidrive/server/internal/core/instance"
 	"github.com/oxidrive/oxidrive/server/internal/web/api"
 )
 
 type Instance struct {
 	Logger zerolog.Logger
-	App    *core.Application
+	App    *app.Application
 }
 
 func (i Instance) Setup(ctx context.Context, request api.InstanceSetupRequestObject) (api.InstanceSetupResponseObject, error) {

--- a/server/internal/web/handler/sessions.go
+++ b/server/internal/web/handler/sessions.go
@@ -40,7 +40,7 @@ func (a *Sessions) CreateSession(ctx context.Context, request api.AuthCreateSess
 
 		return api.AuthCreateSession200JSONResponse(api.Session{
 			ExpiresAt: t.ExpiresAt,
-			Token:     t.String(),
+			Token:     t.Value.String(),
 		}), nil
 	default:
 		a.Logger.Error().Str("kind", string(request.Body.Credentials.Kind)).Msg("invalid credentials kind. This should have been caught by the validation middleware!")

--- a/server/internal/web/handler/sessions.go
+++ b/server/internal/web/handler/sessions.go
@@ -7,14 +7,14 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/oxidrive/oxidrive/server/internal/app"
 	"github.com/oxidrive/oxidrive/server/internal/auth"
-	"github.com/oxidrive/oxidrive/server/internal/core"
 	"github.com/oxidrive/oxidrive/server/internal/web/api"
 )
 
 type Sessions struct {
 	Logger zerolog.Logger
-	App    *core.Application
+	App    *app.Application
 }
 
 func (a *Sessions) CreateSession(ctx context.Context, request api.AuthCreateSessionRequestObject) (api.AuthCreateSessionResponseObject, error) {

--- a/server/internal/web/middleware.go
+++ b/server/internal/web/middleware.go
@@ -9,14 +9,14 @@ import (
 	"github.com/oapi-codegen/runtime/strictmiddleware/nethttp"
 	"github.com/rs/zerolog"
 
+	"github.com/oxidrive/oxidrive/server/internal/app"
 	"github.com/oxidrive/oxidrive/server/internal/auth"
-	"github.com/oxidrive/oxidrive/server/internal/core"
 	"github.com/oxidrive/oxidrive/server/internal/web/api"
 )
 
 type MiddlewareFactory func(zerolog.Logger) (api.MiddlewareFunc, error)
 
-func defaultMiddlewares(logger zerolog.Logger, app *core.Application) ([]api.MiddlewareFunc, error) {
+func defaultMiddlewares(logger zerolog.Logger, app *app.Application) ([]api.MiddlewareFunc, error) {
 	middlewares := make([]api.MiddlewareFunc, 1)
 
 	for i, mf := range []MiddlewareFactory{validator(app)} {
@@ -31,7 +31,7 @@ func defaultMiddlewares(logger zerolog.Logger, app *core.Application) ([]api.Mid
 	return middlewares, nil
 }
 
-func validator(app *core.Application) MiddlewareFactory {
+func validator(app *app.Application) MiddlewareFactory {
 	return func(logger zerolog.Logger) (api.MiddlewareFunc, error) {
 		spec, err := api.GetSwagger()
 		if err != nil {
@@ -47,7 +47,7 @@ func validator(app *core.Application) MiddlewareFactory {
 	}
 }
 
-func userFromToken(app *core.Application) api.StrictMiddlewareFunc {
+func userFromToken(app *app.Application) api.StrictMiddlewareFunc {
 	return api.StrictMiddlewareFunc(func(f nethttp.StrictHTTPHandlerFunc, operationID string) nethttp.StrictHTTPHandlerFunc {
 		return func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (response interface{}, err error) {
 			token := extractTokenFromRequest(r)

--- a/server/internal/web/server.go
+++ b/server/internal/web/server.go
@@ -5,12 +5,12 @@ import (
 
 	"github.com/rs/zerolog"
 
-	"github.com/oxidrive/oxidrive/server/internal/core"
+	"github.com/oxidrive/oxidrive/server/internal/app"
 )
 
 type Config struct {
 	Address            string
-	Application        *core.Application
+	Application        *app.Application
 	Logger             zerolog.Logger
 	FrontendFolder     string
 	MultipartMaxMemory int64

--- a/server/internal/worker/job.go
+++ b/server/internal/worker/job.go
@@ -18,3 +18,8 @@ type defaultHandle struct {
 func (h *defaultHandle) Wait() <-chan error {
 	return h.ch
 }
+
+type CronJob struct {
+	Cron string
+	Job  Job
+}

--- a/server/internal/worker/pool.go
+++ b/server/internal/worker/pool.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/alitto/pond"
-	"github.com/go-co-op/gocron/v2"
 	"github.com/rs/zerolog"
 )
 
@@ -56,61 +55,4 @@ func (p *Pool) Submit(ctx context.Context, j Job) JobHandle {
 
 	l.Debug().Msg("job scheduled successfully")
 	return &defaultHandle{ch}
-}
-
-type Scheduler struct {
-	logger zerolog.Logger
-	sched  gocron.Scheduler
-}
-
-func NewScheduler(logger zerolog.Logger) (*Scheduler, error) {
-	sched, err := gocron.NewScheduler()
-	if err != nil {
-		return nil, err
-	}
-
-	return &Scheduler{
-		sched:  sched,
-		logger: logger,
-	}, nil
-}
-
-func (s *Scheduler) Shutdown() {
-	if err := s.sched.Shutdown(); err != nil {
-		s.logger.Error().Err(err).Msg("failed to shutdown job scheduler")
-	}
-}
-
-func (s *Scheduler) Start() {
-	s.logger.Debug().Msg("starting job scheduler")
-	s.sched.Start()
-}
-
-func (s *Scheduler) Schedule(ctx context.Context, cronexpr string, j Job) (JobHandle, error) {
-	l := s.logger.With().Str("cron", cronexpr).Logger()
-	return s.schedule(ctx, l, gocron.CronJob(cronexpr, false), j)
-}
-
-func (s *Scheduler) ScheduleEvery(ctx context.Context, t time.Duration, j Job) (JobHandle, error) {
-	l := s.logger.With().Dur("everyMS", t).Logger()
-	return s.schedule(ctx, l, gocron.DurationJob(t), j)
-}
-
-func (s *Scheduler) schedule(ctx context.Context, l zerolog.Logger, def gocron.JobDefinition, j Job) (JobHandle, error) {
-	ch := make(chan error)
-	l = l.With().Str("job", j.Name()).Logger()
-
-	_, err := s.sched.NewJob(def, gocron.NewTask(func() {
-		l.Debug().Msg("starting job run...")
-		err := j.Run(ctx)
-		l.Debug().Err(err).Msg("job run completed")
-		ch <- err
-	}))
-
-	if err != nil {
-		return nil, err
-	}
-
-	l.Debug().Msg("job scheduled successfully")
-	return &defaultHandle{ch}, nil
 }

--- a/server/internal/worker/pool_test.go
+++ b/server/internal/worker/pool_test.go
@@ -5,10 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/oxidrive/oxidrive/server/internal/testutil"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type testJob struct {
@@ -66,34 +64,6 @@ func TestWorkerPool(t *testing.T) {
 			t.Fatal("received result instead of timeout expiring")
 		case <-ctx.Done():
 			// Pass
-		}
-	})
-}
-
-func TestWorkerScheduler(t *testing.T) {
-	t.Run("schedules a background job", func(t *testing.T) {
-		t.Parallel()
-
-		ctx, done := context.WithTimeout(context.Background(), 3*time.Second)
-		defer done()
-
-		testutil.IntegrationTest(ctx, t)
-
-		p, err := NewScheduler(zerolog.New(zerolog.NewTestWriter(t)))
-		require.NoError(t, err)
-		defer p.Shutdown()
-
-		ch := make(chan struct{})
-
-		_, err = p.ScheduleEvery(ctx, 1*time.Second, &testJob{done: ch})
-		require.NoError(t, err)
-
-		p.Start()
-
-		select {
-		case <-ch:
-		case <-ctx.Done():
-			t.Fatal("context timeout expired")
 		}
 	})
 }

--- a/server/internal/worker/run.go
+++ b/server/internal/worker/run.go
@@ -1,0 +1,32 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+)
+
+type Config struct {
+	Logger  zerolog.Logger
+	Crontab []CronJob
+}
+
+func StartScheduled(cfg Config) error {
+	ctx := context.Background()
+
+	s, err := NewScheduler(cfg.Logger)
+	if err != nil {
+		return err
+	}
+
+	for _, j := range cfg.Crontab {
+		_, err := s.Schedule(ctx, j.Cron, j.Job)
+		if err != nil {
+			return err
+		}
+	}
+
+	s.Start()
+
+	return nil
+}

--- a/server/internal/worker/scheduler.go
+++ b/server/internal/worker/scheduler.go
@@ -1,0 +1,66 @@
+package worker
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-co-op/gocron/v2"
+	"github.com/rs/zerolog"
+)
+
+type Scheduler struct {
+	logger zerolog.Logger
+	sched  gocron.Scheduler
+}
+
+func NewScheduler(logger zerolog.Logger) (*Scheduler, error) {
+	sched, err := gocron.NewScheduler()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Scheduler{
+		sched:  sched,
+		logger: logger,
+	}, nil
+}
+
+func (s *Scheduler) Shutdown() {
+	if err := s.sched.Shutdown(); err != nil {
+		s.logger.Error().Err(err).Msg("failed to shutdown job scheduler")
+	}
+}
+
+func (s *Scheduler) Start() {
+	s.logger.Info().Int("jobs", len(s.sched.Jobs())).Msg("starting job scheduler")
+	s.sched.Start()
+}
+
+func (s *Scheduler) Schedule(ctx context.Context, cronexpr string, j Job) (JobHandle, error) {
+	l := s.logger.With().Str("cron", cronexpr).Logger()
+	return s.schedule(ctx, l, gocron.CronJob(cronexpr, false), j)
+}
+
+func (s *Scheduler) ScheduleEvery(ctx context.Context, t time.Duration, j Job) (JobHandle, error) {
+	l := s.logger.With().Dur("everyMS", t).Logger()
+	return s.schedule(ctx, l, gocron.DurationJob(t), j)
+}
+
+func (s *Scheduler) schedule(ctx context.Context, l zerolog.Logger, def gocron.JobDefinition, j Job) (JobHandle, error) {
+	ch := make(chan error)
+	l = l.With().Str("job", j.Name()).Logger()
+
+	_, err := s.sched.NewJob(def, gocron.NewTask(func() {
+		l.Debug().Msg("starting job run...")
+		err := j.Run(ctx)
+		l.Debug().Err(err).Msg("job run completed")
+		ch <- err
+	}))
+
+	if err != nil {
+		return nil, err
+	}
+
+	l.Debug().Msg("job scheduled successfully")
+	return &defaultHandle{ch}, nil
+}

--- a/server/internal/worker/scheduler_test.go
+++ b/server/internal/worker/scheduler_test.go
@@ -1,0 +1,59 @@
+package worker
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxidrive/oxidrive/server/internal/testutil"
+)
+
+type testCron struct {
+	done  chan struct{}
+	sleep time.Duration
+}
+
+var _ Job = (*testCron)(nil)
+
+func (j *testCron) Name() string {
+	return "test job"
+}
+
+func (j *testCron) Run(_ context.Context) error {
+	time.Sleep(j.sleep)
+	if j.done != nil {
+		j.done <- struct{}{}
+	}
+	return nil
+}
+
+func TestWorkerScheduler(t *testing.T) {
+	t.Run("schedules a background job", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, done := context.WithTimeout(context.Background(), 3*time.Second)
+		defer done()
+
+		testutil.IntegrationTest(ctx, t)
+
+		p, err := NewScheduler(zerolog.New(zerolog.NewTestWriter(t)))
+		require.NoError(t, err)
+		defer p.Shutdown()
+
+		ch := make(chan struct{})
+
+		_, err = p.ScheduleEvery(ctx, 1*time.Second, &testCron{done: ch})
+		require.NoError(t, err)
+
+		p.Start()
+
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			t.Fatal("context timeout expired")
+		}
+	})
+}


### PR DESCRIPTION
Run a background job every X minutes to delete expired tokens from the database.
This is just a housekeeping job, the authentication system ignores expired tokens anyway, but at least we avoid having the tokens table grow indefinitely.

Pointing to `background-workers` only for the smaller diff, we'll rebase onto `main` when #43 is closed