### PR TITLE
File rename

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -117,6 +117,12 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
-        name: playwright-report-${{ matrix.project }}
-        path: e2e/playwright-report
+        name: playwright-report-${{ matrix.project }}-${{ matrix.database }}-${{ matrix.storage }}
+        path: playwright-report
+        retention-days: 30
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: test-results-${{ matrix.project }}-${{ matrix.database }}-${{ matrix.storage }}
+        path: test-results
         retention-days: 30

--- a/e2e/tests/file-operations.spec.ts
+++ b/e2e/tests/file-operations.spec.ts
@@ -99,19 +99,18 @@ function upload({ page, name, content, folder }: StepArgs): Step<Locator> {
 		await page.waitForLoadState("networkidle");
 
 		const toasts = await page.getByRole("alert").all();
-		for (const toast of toasts) {
-			await expect(toast).toBeVisible();
-			await expect(toast).toHaveAttribute("data-toast-level", "info");
-			await expect(toast).toContainText(name);
-		}
 
 		await Promise.allSettled(
-			toasts.map((toast) => toast.getByTitle("Close toast").click()),
+			toasts.map(async (toast) => {
+				await expect(toast).toBeVisible();
+				await expect(toast).toHaveAttribute("data-toast-level", "info");
+				await expect(toast).toContainText(name);
+				await toast.getByTitle("Close toast").click();
+			}),
 		);
 
-		await expect(page.getByText("No files in here")).not.toBeVisible();
-
 		const file = page.getByTitle(folder ?? name, { exact: true }).first();
+		await file.scrollIntoViewIfNeeded();
 		await expect(file).toBeVisible();
 		return file;
 	};

--- a/e2e/tests/file-operations.spec.ts
+++ b/e2e/tests/file-operations.spec.ts
@@ -25,7 +25,8 @@ function upload({ page, name, content }: StepArgs): Step<Locator> {
 
 		const filechooserPromise = page.waitForEvent("filechooser");
 
-		await page.getByTitle("Upload").click();
+		await page.getByRole("button", { name: "Create" }).click();
+		await page.getByRole("menuitem", { name: "Upload file" }).click();
 
 		const filechooser = await filechooserPromise;
 		await filechooser.setFiles({

--- a/e2e/tests/file-operations.spec.ts
+++ b/e2e/tests/file-operations.spec.ts
@@ -6,7 +6,9 @@ test(
 	testAccessibility("/files"),
 );
 
-test("should upload, preview, and download a file", async ({ page }) => {
+test("should upload, preview, download, and delete a file", async ({
+	page,
+}) => {
 	const name = `hello${Math.random().toString().substring(2)}.json`;
 	const content = '{"hello":"world!"}';
 
@@ -17,9 +19,68 @@ test("should upload, preview, and download a file", async ({ page }) => {
 	const file = await test.step("Upload file", upload({ page, name, content }));
 	await test.step("Preview file", preview(file, { page, name, content }));
 	await test.step("Download file", download(file, { page, name, content }));
+	await test.step("Delete file", remove(file, { page, name, content }));
 });
 
-function upload({ page, name, content }: StepArgs): Step<Locator> {
+test("should upload, rename, and delete a file", async ({ page }) => {
+	const run = Math.random().toString().substring(2);
+	const name = `hello${run}.json`;
+	const newName = `changed${run}.json`;
+	const content = '{"hello":"world!"}';
+
+	await page.goto("/files");
+	await page.waitForLoadState("networkidle");
+	await expect(page).toHaveURL("/files");
+
+	const file = await test.step("Upload file", upload({ page, name, content }));
+	const renamed = await test.step(
+		"Rename file",
+		rename(file, newName, { page, name, content }),
+	);
+	await test.step(
+		"Delete file",
+		remove(renamed, { page, name: newName, content }),
+	);
+});
+
+test("should upload, and rename a folder", async ({ page }) => {
+	const run = Math.random().toString().substring(2);
+	const folderName = `tests${run}`;
+	const newFolderName = `changed${run}`;
+	const fileName = `hello${run}.json`;
+	const name = `${folderName}/${fileName}`;
+	const content = '{"hello":"world!"}';
+
+	await page.goto("/files");
+	await page.waitForLoadState("networkidle");
+	await expect(page).toHaveURL("/files");
+
+	await test.step(
+		"Upload file",
+		upload({ page, name, content, folder: folderName }),
+	);
+	const folder = page.getByTitle(folderName, { exact: true }).first();
+	await test.step(
+		"Rename folder",
+		rename(folder, newFolderName, { page, name, content }),
+	);
+
+	await page.getByRole("link", { name: newFolderName, exact: true }).click();
+
+	await expect(page).toHaveURL(`/files/${newFolderName}`);
+
+	const file = page.getByTitle(fileName, { exact: true }).first();
+	await test.step(
+		"Preview file",
+		preview(file, { page, name: fileName, content }),
+	);
+	await test.step(
+		"Delete file",
+		remove(file, { page, name: fileName, content }),
+	);
+});
+
+function upload({ page, name, content, folder }: StepArgs): Step<Locator> {
 	return async () => {
 		await expect(page.getByText(name)).not.toBeVisible();
 
@@ -50,13 +111,13 @@ function upload({ page, name, content }: StepArgs): Step<Locator> {
 
 		await expect(page.getByText("No files in here")).not.toBeVisible();
 
-		const file = page.getByTitle(name, { exact: true }).first();
+		const file = page.getByTitle(folder ?? name, { exact: true }).first();
 		await expect(file).toBeVisible();
 		return file;
 	};
 }
 
-function preview(file: Locator, { page, name, content }: StepArgs): Step {
+function preview(file: Locator, { page, name }: StepArgs): Step {
 	return async () => {
 		await file.click();
 
@@ -97,10 +158,54 @@ function download(file: Locator, { page, name }: StepArgs): Step {
 	};
 }
 
+function rename(
+	file: Locator,
+	newName: string,
+	{ page }: StepArgs,
+): Step<Locator> {
+	return async () => {
+		const actions = file.getByTestId("file-actions");
+
+		await expect(actions).toBeVisible();
+		await actions.click();
+
+		const action = page.getByRole("menuitem", { name: "Rename" });
+		await expect(action).toBeVisible();
+		await action.click();
+
+		const input = page.getByRole("textbox");
+		await expect(input).toBeVisible();
+		await input.fill(newName);
+		await page.keyboard.press("Enter");
+
+		const renamed = page.getByTitle(newName, { exact: true }).first();
+		await expect(renamed).toBeVisible();
+		return renamed;
+	};
+}
+
+function remove(file: Locator, { page }: StepArgs): Step {
+	return async () => {
+		page.on("dialog", (dialog) => dialog.accept());
+
+		const actions = file.getByTestId("file-actions");
+
+		await expect(actions).toBeVisible();
+		await actions.click();
+
+		const action = page.getByRole("menuitem", { name: "Delete" });
+		await expect(action).toBeVisible();
+		await action.click();
+
+		await expect(file).not.toBeVisible();
+	};
+}
+
 interface StepArgs {
 	page: Page;
 	name: string;
 	content: string;
+	folder?: string;
 }
 
 type Step<T = void> = () => Promise<T>;

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,7 +1,7 @@
-DATABASE_URL=postgres://oxidrive:oxidrive@localhost:5432/oxidrive?sslmode=disable
+DATABASE_URL=sqlite://./data/oxidrive.db
 LOG_FORMAT=text
 LOG_LEVEL=debug
-OXIDRIVE_ASSETS_FOLDER=../web/app/dist
-PUBLIC_URL=http://localhost:8080
+OXIDRIVE_ASSETS_FOLDER=../web/build
+PUBLIC_URL=http://localhost:5137
 
 OXIDRIVE_STORAGE_FS_DATA_DIR=./data

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=sqlite://./data/oxidrive.db
+DATABASE_URL=postgres://oxidrive:oxidrive@localhost:5432/oxidrive?sslmode=disable
 LOG_FORMAT=text
 LOG_LEVEL=debug
 OXIDRIVE_ASSETS_FOLDER=../web/build

--- a/server/internal/core/file/file.go
+++ b/server/internal/core/file/file.go
@@ -106,21 +106,25 @@ func Create(content Content, ct ContentType, p Path, size Size, ownerID user.ID)
 	}, nil
 }
 
-func (f *File) Update(content Content, ct ContentType, p Path, size Size) error {
+func (f *File) UpdateContent(content Content, ct ContentType, size Size) error {
 	if f.Type != TypeFile {
 		return ErrFolderUpdate
 	}
 
+	f.Content = content
+	f.ContentType = ct
+	f.Size = size
+	return nil
+}
+
+func (f *File) ChangePath(p Path) error {
 	p, err := ParsePath(string(p))
 	if err != nil {
 		return err
 	}
 
-	f.Content = content
-	f.ContentType = ct
 	f.Name = p.Name()
 	f.Path = p
-	f.Size = size
 	return nil
 }
 
@@ -134,6 +138,19 @@ func (f *File) Folder() *Folder {
 	return &Folder{
 		Name: Name(n),
 		Path: Path(p),
+	}
+}
+
+func (f *File) Clone() File {
+	return File{
+		ID:          f.ID,
+		Type:        f.Type,
+		ContentType: f.ContentType,
+		Content:     nil,
+		Name:        f.Name,
+		Path:        f.Path,
+		Size:        f.Size,
+		OwnerID:     f.OwnerID,
 	}
 }
 
@@ -167,6 +184,7 @@ type Contents interface {
 	Store(context.Context, File) error
 	Load(context.Context, File) (Content, error)
 	Delete(context.Context, File) error
+	Copy(ctx context.Context, from File, to File) error
 }
 
 type Files interface {

--- a/server/internal/core/file/file_mock.go
+++ b/server/internal/core/file/file_mock.go
@@ -38,6 +38,11 @@ func (c *ContentsMock) Delete(_ context.Context, file File) error {
 	return args.Error(0)
 }
 
+func (c *ContentsMock) Copy(ctx context.Context, from File, to File) error {
+	args := c.Called(from, to)
+	return args.Error(0)
+}
+
 var _ Files = (*FilesMock)(nil)
 
 type FilesMock struct {

--- a/server/internal/core/file/file_test.go
+++ b/server/internal/core/file/file_test.go
@@ -46,7 +46,7 @@ func Test_Create(t *testing.T) {
 
 }
 
-func Test_Update(t *testing.T) {
+func Test_ChangePath(t *testing.T) {
 	testCases := []struct {
 		testName         string
 		filename         string
@@ -70,7 +70,7 @@ func Test_Update(t *testing.T) {
 			file, err := Create(nil, "text/plain", originalPath, 5, user.ID(testutil.Must(uuid.NewV7())))
 			require.NoError(t, err)
 
-			err = file.Update(nil, "text/plain", Path(testCase.filename), 5)
+			err = file.ChangePath(Path(testCase.filename))
 
 			if testCase.expectedFilepath != nil {
 				assert.Equal(t, *testCase.expectedFilepath, string(file.Path))

--- a/server/internal/core/file/service_test.go
+++ b/server/internal/core/file/service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/oxidrive/oxidrive/server/internal/core/list"
 	"github.com/oxidrive/oxidrive/server/internal/core/user"
 	"github.com/oxidrive/oxidrive/server/internal/testutil"
 )
@@ -141,7 +142,7 @@ func TestService_Upload(t *testing.T) {
 		size := 10
 		owner := user.NewID()
 
-		file, err := Create(content, ct, "original", Size(size), owner)
+		file, err := Create(content, ct, filepath, Size(size), owner)
 		require.NoError(t, err)
 
 		filesMock.On("ByOwnerByPath", owner, filepath).Return((*File)(file), nil).Once()
@@ -155,6 +156,158 @@ func TestService_Upload(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, file.ID, id)
+	})
+}
+
+func TestService_Move(t *testing.T) {
+	t.Run("moves a file to a valid path", func(t *testing.T) {
+		t.Parallel()
+
+		contentsMock := NewContentsMock(t)
+		filesMock := NewFilesMock(t)
+
+		service := NewService(contentsMock, filesMock)
+
+		ctx := context.Background()
+
+		owner := user.NewID()
+		f, err := Create(strings.NewReader(""), "text/plain", "test.txt", 0, owner)
+		require.NoError(t, err)
+		require.NotNil(t, f)
+		isF := mock.MatchedBy(func(fu File) bool { return fu.ID == f.ID && fu.Path == f.Path })
+
+		newPath := Path("/hello.txt")
+		u := f.Clone()
+		u.Path = newPath
+		isU := mock.MatchedBy(func(fu File) bool { return fu.ID == u.ID && fu.Path == u.Path })
+
+		contentsMock.On("Copy", isF, isU).Return(nil).Once()
+		contentsMock.On("Delete", isF).Return(nil).Once()
+		filesMock.On("Save", isU).Return(&u, nil).Once()
+
+		updated, err := service.Move(ctx, *f, newPath)
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+
+		defer contentsMock.AssertExpectations(t)
+		defer filesMock.AssertExpectations(t)
+
+		assert.Equal(t, f.ID, updated.ID)
+		assert.Equal(t, newPath, updated.Path)
+	})
+
+	t.Run("recursively moves a folder and all its children", func(t *testing.T) {
+		t.Parallel()
+
+		contentsMock := NewContentsMock(t)
+		filesMock := NewFilesMock(t)
+
+		service := NewService(contentsMock, filesMock)
+
+		ctx := context.Background()
+
+		owner := user.NewID()
+		newPath := Path("/renamed")
+
+		f1, err := Create(strings.NewReader(""), "text/plain", "/folder/test.txt", 0, owner)
+		require.NoError(t, err)
+		require.NotNil(t, f1)
+		u1 := f1.Clone()
+		u1.Path = newPath + "/test.txt"
+		isF1 := mock.MatchedBy(func(fu File) bool { return fu.ID == f1.ID && fu.Path == f1.Path })
+		isU1 := mock.MatchedBy(func(fu File) bool { return fu.ID == u1.ID && fu.Path == u1.Path })
+
+		f2, err := Create(strings.NewReader(""), "text/plain", "/folder/deep/test.txt", 0, owner)
+		require.NoError(t, err)
+		require.NotNil(t, f1)
+		u2 := f2.Clone()
+		u2.Path = newPath + "/deep/test.txt"
+		isF2 := mock.MatchedBy(func(fu File) bool { return fu.ID == f2.ID && fu.Path == f2.Path })
+		isU2 := mock.MatchedBy(func(fu File) bool { return fu.ID == u2.ID && fu.Path == u2.Path })
+
+		d1 := File{
+			ID:          NewID(),
+			Type:        TypeFolder,
+			ContentType: ContentTypeFolder,
+			Content:     nil,
+			Name:        "folder",
+			Path:        "/folder",
+			Size:        0,
+			OwnerID:     owner,
+		}
+		du1 := d1.Clone()
+		du1.Path = newPath
+		isDU1 := mock.MatchedBy(func(fu File) bool { return fu.ID == du1.ID && fu.Path == du1.Path })
+
+		d2 := File{
+			ID:          NewID(),
+			Type:        TypeFolder,
+			ContentType: ContentTypeFolder,
+			Content:     nil,
+			Name:        "deep",
+			Path:        "/folder/deep",
+			Size:        0,
+			OwnerID:     owner,
+		}
+		du2 := d2.Clone()
+		du2.Path = newPath + "/deep"
+		isDU2 := mock.MatchedBy(func(fu File) bool { return fu.ID == du2.ID && fu.Path == du2.Path })
+
+		ff1 := list.Of[File]{
+			Items: []File{d2, *f1},
+			Count: 2,
+			Total: 2,
+			Next:  nil,
+		}
+
+		ff2 := list.Of[File]{
+			Items: []File{*f2},
+			Count: 1,
+			Total: 1,
+			Next:  nil,
+		}
+
+		contentsMock.On("Copy", isF1, isU1).Return(nil).Once()
+		contentsMock.On("Delete", isF1).Return(nil).Once()
+		contentsMock.On("Copy", isF2, isU2).Return(nil).Once()
+		contentsMock.On("Delete", isF2).Return(nil).Once()
+		filesMock.On("List", &d1.Path, list.NewParams()).Return(ff1, nil).Once()
+		filesMock.On("List", &d2.Path, list.NewParams()).Return(ff2, nil).Once()
+		filesMock.On("Save", isU1).Return(&u1, nil).Once()
+		filesMock.On("Save", isU2).Return(&u2, nil).Once()
+		filesMock.On("Save", isDU1).Return(&du1, nil).Once()
+		filesMock.On("Save", isDU2).Return(&du2, nil).Once()
+
+		updated, err := service.Move(ctx, d1, newPath)
+		require.NoError(t, err)
+		require.NotNil(t, updated)
+
+		defer contentsMock.AssertExpectations(t)
+		defer filesMock.AssertExpectations(t)
+
+		assert.Equal(t, d1.ID, updated.ID)
+		assert.Equal(t, newPath, updated.Path)
+	})
+
+	t.Run("returns an error if the file does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		contentsMock := NewContentsMock(t)
+		filesMock := NewFilesMock(t)
+
+		service := NewService(contentsMock, filesMock)
+
+		ctx := context.Background()
+
+		id := NewID()
+
+		filesMock.On("ByID", id).Return((*File)(nil), nil).Once()
+
+		err := service.Delete(ctx, id)
+		assert.Equal(t, err, ErrFileNotFound)
+
+		defer contentsMock.AssertExpectations(t)
+		defer filesMock.AssertExpectations(t)
 	})
 }
 

--- a/server/internal/infrastructure/file/content_fs.go
+++ b/server/internal/infrastructure/file/content_fs.go
@@ -129,6 +129,24 @@ func (c *contentFS) Delete(ctx context.Context, f file.File) error {
 	return nil
 }
 
+func (c *contentFS) Copy(ctx context.Context, from file.File, to file.File) error {
+	fromPath := c.pathFor(from)
+	toPath := c.pathFor(to)
+
+	if fromPath == toPath {
+		// noop
+		return nil
+	}
+
+	content, err := c.Load(ctx, from)
+	if err != nil {
+		return fmt.Errorf("failed to open source file for copy: %w", err)
+	}
+
+	to.Content = content
+	return c.Store(ctx, to)
+}
+
 func (c *contentFS) pathFor(f file.File) string {
 	return filepath.Join(c.dataDir, c.filesPrefix, f.OwnerID.String(), string(f.Path))
 }

--- a/server/internal/infrastructure/file/files_pg.go
+++ b/server/internal/infrastructure/file/files_pg.go
@@ -98,64 +98,43 @@ select * from numbered_files where cursor >= $1 limit $3
 }
 
 func (p *PgFiles) Save(ctx context.Context, f file.File) (*file.File, error) {
-	if f.Type == file.TypeFolder {
-		return nil, file.ErrFolderSave
-	}
-
 	tx, err := p.db.BeginTxx(ctx, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open DB transaction: %w", err)
 	}
 
-	if err := p.saveFolder(ctx, tx, &f); err != nil {
+	if err := p.ensureParentFolder(ctx, tx, f); err != nil {
 		if err := tx.Rollback(); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to rollback DB transaction: %w", err)
 		}
-		return nil, err
+		return nil, fmt.Errorf("failed to save folder in DB: %w", err)
 	}
 
-	_, err = tx.ExecContext(ctx, `insert into files (
-        id,
-        type,
-        content_type,
-        name,
-        path,
-        size,
-        user_id
-    ) values (
-        $1,
-        $2,
-        $3,
-        $4,
-        $5,
-        $6,
-        $7
-    )
-    on conflict (id)
-    do update set
-      type = excluded.type,
-      content_type = excluded.content_type,
-      name = excluded.name,
-      path = excluded.path,
-      size = excluded.size
-    ;`, f.ID.String(), f.Type, f.ContentType, f.Name, f.Path, f.Size, f.OwnerID.String())
+	switch f.Type {
+	case file.TypeFile:
+		err = p.upsertFile(ctx, tx, f)
+	case file.TypeFolder:
+		err = p.upsertFolder(ctx, tx, f)
+	default:
+		panic("unexpected file type " + f.Type)
+	}
 
 	if err != nil {
 		if err := tx.Rollback(); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to rollback DB transaction: %w", err)
 		}
 
-		return nil, err
+		return nil, fmt.Errorf("failed to save file in DB: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to commit DB transaction: %w", err)
 	}
 
 	return &f, nil
 }
 
-func (p *PgFiles) saveFolder(ctx context.Context, tx *sqlx.Tx, f *file.File) error {
+func (p *PgFiles) ensureParentFolder(ctx context.Context, tx *sqlx.Tx, f file.File) error {
 	d := f.Folder()
 	if d == nil {
 		return nil
@@ -179,11 +158,64 @@ func (p *PgFiles) saveFolder(ctx context.Context, tx *sqlx.Tx, f *file.File) err
         $7
     )
     on conflict (path)
-    do update set
-      type = excluded.type,
-      size = files.size + excluded.size
+    do nothing
     ;`, file.NewID(), file.TypeFolder, file.ContentTypeFolder, d.Name, d.Path, f.Size, f.OwnerID)
 
+	return err
+}
+
+func (p *PgFiles) upsertFile(ctx context.Context, tx *sqlx.Tx, f file.File) error {
+	_, err := tx.ExecContext(ctx, `insert into files (
+        id,
+        type,
+        content_type,
+        name,
+        path,
+        size,
+        user_id
+    ) values (
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        $6,
+        $7
+    )
+    on conflict (id)
+    do update set
+      content_type = excluded.content_type,
+      name = excluded.name,
+      path = excluded.path,
+      size = excluded.size
+    ;`, f.ID.String(), f.Type, f.ContentType, f.Name, f.Path, f.Size, f.OwnerID.String())
+	return err
+}
+func (p *PgFiles) upsertFolder(ctx context.Context, tx *sqlx.Tx, f file.File) error {
+	_, err := tx.ExecContext(ctx, `insert into files (
+        id,
+        type,
+        content_type,
+        name,
+        path,
+        size,
+        user_id
+    ) values (
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        $6,
+        $7
+    )
+    on conflict (id)
+    do update set
+      path = excluded.path,
+      content_type = excluded.content_type,
+      name = excluded.name,
+      size = excluded.size
+    ;`, f.ID.String(), f.Type, f.ContentType, f.Name, f.Path, f.Size, f.OwnerID.String())
 	return err
 }
 

--- a/server/internal/infrastructure/file/files_pg_test.go
+++ b/server/internal/infrastructure/file/files_pg_test.go
@@ -292,7 +292,6 @@ func TestPgFiles_Save(t *testing.T) {
 		assert.Equal(t, file.TypeFolder, d.Type)
 		assert.Equal(t, savedFolder.Name, d.Name)
 		assert.Equal(t, savedFolder.Path, d.Path)
-		assert.Equal(t, saved1.Size+saved2.Size, d.Size)
 
 		f1 := ff.Items[1]
 		assert.Equal(t, saved1.ID, f1.ID)

--- a/server/internal/infrastructure/file/files_sqlite_test.go
+++ b/server/internal/infrastructure/file/files_sqlite_test.go
@@ -281,7 +281,6 @@ func TestSqliteFiles_Save(t *testing.T) {
 		assert.Equal(t, file.TypeFolder, d.Type)
 		assert.Equal(t, savedFolder.Name, d.Name)
 		assert.Equal(t, savedFolder.Path, d.Path)
-		assert.Equal(t, saved1.Size+saved2.Size, d.Size)
 
 		f1 := ff.Items[1]
 		assert.Equal(t, saved1.ID, f1.ID)

--- a/server/internal/web/api.go
+++ b/server/internal/web/api.go
@@ -78,6 +78,10 @@ func (api *Api) FilesUpload(ctx context.Context, request api.FilesUploadRequestO
 	return api.files.Upload(ctx, request)
 }
 
+func (api *Api) FilePatch(ctx context.Context, request api.FilePatchRequestObject) (api.FilePatchResponseObject, error) {
+	return api.files.Patch(ctx, request)
+}
+
 func (api *Api) FileDelete(ctx context.Context, request api.FileDeleteRequestObject) (api.FileDeleteResponseObject, error) {
 	return api.files.Delete(ctx, request)
 }

--- a/server/openapi/files.yaml
+++ b/server/openapi/files.yaml
@@ -48,16 +48,44 @@ paths:
           $ref: './openapi.yaml#/components/responses/InternalError'
 
   /api/files/{id}:
+    patch:
+      operationId: filePatch
+      summary: Change a file's metadata
+      tags: [files]
+      security:
+        - session: []
+      parameters:
+        - $ref: '#/components/parameters/FileID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FilePatch'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/File'
+        '400':
+          description: One or more request param is invalid
+          $ref: '#/components/responses/InvalidParams'
+        '404':
+          description: The requested file does not exist or cannot be accessed
+          $ref: './openapi.yaml#/components/responses/NotFound'
+        default:
+          $ref: './openapi.yaml#/components/responses/InternalError'
+
+
     delete:
       operationId: fileDelete
+      summary: Delete a file
+      tags: [files]
+      security:
+        - session: []
       parameters:
-        - in: path
-          name: id
-          schema:
-            type: string
-            format: uuid
-          required: true
-          description: Id of the file to delete
+        - $ref: '#/components/parameters/FileID'
       responses:
         '200':
           content:
@@ -72,6 +100,15 @@ paths:
 
 components:
   parameters:
+    FileID:
+      in: path
+      name: id
+      schema:
+        type: string
+        format: uuid
+      required: true
+      description: ID of the requested file
+
     FilePrefix:
       name: prefix
       in: query
@@ -82,6 +119,13 @@ components:
       schema:
         type: string
         format: path
+
+  responses:
+    InvalidParams:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/InvalidFileParamsError'
 
   schemas:
     File:
@@ -149,4 +193,43 @@ components:
         ok:
           type: boolean
         id:
+          type: string
+
+    FilePatch:
+      type: object
+      properties:
+        path:
+          type: string
+          format: path
+          description: |
+            New path of the file.
+            To simply rename it, set to the current path with the last segment changed.
+            E.g.: path/to/file.txt -> path/to/renamed.txt
+          example: "path/to/file.txt"
+
+    InvalidFileParamsError:
+      allOf:
+        - $ref: './openapi.yaml#/components/schemas/InvalidParamsError'
+        - type: object
+          required:
+            - errors
+          properties:
+            errors:
+              type: array
+              items:
+                $ref: '#/components/schemas/InvalidFileParamError'
+    
+    InvalidFileParamError:
+      type: object
+      required:
+        - param
+        - reason
+        - message
+      properties:
+        param:
+          type: string
+          description: The name of the invalid parameter
+        reason:
+          type: string
+        message:
           type: string

--- a/server/openapi/openapi.yaml
+++ b/server/openapi/openapi.yaml
@@ -75,6 +75,19 @@ components:
           type: string
           description: human readable error message
 
+    InvalidParamsError:
+      type: object
+      required:
+        - error
+        - message
+      properties:
+        error:
+          type: string
+          enum: [invalid_params]
+        message:
+          type: string
+          description: human readable error message
+
     ListInfo:
       type: object
       required:

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -19,3 +19,4 @@ export class ApiError extends Error {
 export type ErrorResponse = components["schemas"]["Error"];
 export type FileList = components["schemas"]["FileList"];
 export type File = components["schemas"]["File"];
+export type FileType = File["type"];

--- a/web/src/lib/components/Toast.svelte
+++ b/web/src/lib/components/Toast.svelte
@@ -83,12 +83,14 @@ export function reportError(
         display: flex;
         flex-direction: column;
         gap: var(--oxi-size-2);
-        max-width: 100vw;
+        max-width: 90vw;
     }
 
     .toast {
         padding: var(--oxi-size-2);
         border-radius: var(--oxi-rounded-2xl);
+        word-break: break-word;
+        hyphens: auto;
 
         &.info {
             background-color: var(--oxi-color-primary-50);

--- a/web/src/lib/components/Toast.svelte
+++ b/web/src/lib/components/Toast.svelte
@@ -83,6 +83,7 @@ export function reportError(
         display: flex;
         flex-direction: column;
         gap: var(--oxi-size-2);
+        max-width: 100vw;
     }
 
     .toast {

--- a/web/src/lib/components/buttons/Fab.svelte
+++ b/web/src/lib/components/buttons/Fab.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/svelte-fontawesome";
+import { createDropdownMenu, melt } from "@melt-ui/svelte";
+import { fly } from "svelte/transition";
+
+export let color: "primary" | "secondary";
+export let icon: IconDefinition;
+export let title: string;
+export let multiple = false;
+
+const {
+	elements: { trigger, menu, item },
+	states: { open },
+} = createDropdownMenu({ portal: null });
+</script>
+
+{#if multiple}
+    <div class="fab-multi">
+        <button use:melt={$trigger} class="fab {color}" {title}>
+            <FontAwesomeIcon {icon} />
+        </button>
+
+        {#if $open}
+            <div
+                class="fab-children"
+                use:melt={$menu}
+                transition:fly={{ duration: 150, y: 10 }}
+            >
+                <slot />
+            </div>
+        {/if}
+    </div>
+{:else}
+    <button class="fab {color}" {title} on:click use:melt={$item}>
+        <FontAwesomeIcon {icon} />
+
+        <slot />
+    </button>
+{/if}

--- a/web/src/lib/components/files/FileActions.svelte
+++ b/web/src/lib/components/files/FileActions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { File } from "$lib/api";
+import type { File, FileType } from "$lib/api";
 import { createDropdownMenu, melt } from "@melt-ui/svelte";
 import { Localized } from "@nubolab-ffwd/svelte-fluent";
 import { createEventDispatcher } from "svelte";
@@ -10,12 +10,13 @@ interface Action {
 	icon: `fa-${string} fa-${string}`;
 	action: Actions;
 	disabled?: true;
+	type: FileType | "all";
 }
 
 const actions: Action[] = [
-	{ action: "rename", icon: "fa-solid fa-pencil", disabled: true },
-	{ action: "download", icon: "fa-solid fa-download" },
-	{ action: "delete", icon: "fa-solid fa-trash" },
+	{ action: "rename", icon: "fa-solid fa-pencil", type: "all" },
+	{ action: "download", icon: "fa-solid fa-download", type: "file" },
+	{ action: "delete", icon: "fa-solid fa-trash", type: "file" },
 ];
 
 const dispatch = createEventDispatcher<Record<Actions, File>>();
@@ -40,7 +41,7 @@ const {
         <i class="fa-solid fa-ellipsis text-primary-500"></i>
     </button>
     <div use:melt={$menu} class="file-actions">
-        {#each actions as { icon, action, disabled }}
+        {#each actions.filter(({ type }) => type === 'all' || type === file.type) as { icon, action, disabled }}
             <button
                 use:melt={$item}
                 class="action"

--- a/web/src/lib/components/files/FileLink.svelte
+++ b/web/src/lib/components/files/FileLink.svelte
@@ -13,7 +13,7 @@ export { clazz as class };
 
 {#if file.type === "folder"}
     <Localized id="files-link-open-folder" let:text args={{ file: file.name }}>
-        <a class={clazz} href={file.path} title={text}><slot /></a>
+        <a class={clazz} href="/files{file.path}" title={text}><slot /></a>
     </Localized>
 {:else}
     <button

--- a/web/src/lib/components/files/FilesGrid.svelte
+++ b/web/src/lib/components/files/FilesGrid.svelte
@@ -6,11 +6,12 @@ import FileActions from "./FileActions.svelte";
 import FileIcon from "./FileIcon.svelte";
 import FileLink from "./FileLink.svelte";
 
-type EventHandler = (
+type InputEventHandler = (
 	ev: Event & { currentTarget: EventTarget & HTMLInputElement },
 ) => void;
 
 const dispatch = createEventDispatcher<{
+	rename: File;
 	selected: File;
 	deselected: File;
 }>();
@@ -18,7 +19,9 @@ const dispatch = createEventDispatcher<{
 export let files: FileList;
 export let selected: Set<File>;
 
-function select(file: File): EventHandler {
+let renaming: File | null;
+
+function select(file: File): InputEventHandler {
 	return (ev) => {
 		if (ev.currentTarget.checked) {
 			dispatch("selected", file);
@@ -26,6 +29,25 @@ function select(file: File): EventHandler {
 			dispatch("deselected", file);
 		}
 	};
+}
+
+function startRenaming({ detail: file }: CustomEvent<File>) {
+	if (renaming) {
+		renaming = null;
+	} else {
+		renaming = file;
+	}
+}
+
+function rename() {
+	if (!renaming) return;
+
+	dispatch("rename", renaming);
+	renaming = null;
+}
+
+function focus(input: HTMLInputElement) {
+	setTimeout(() => input.focus(), 100);
 }
 </script>
 
@@ -49,11 +71,16 @@ function select(file: File): EventHandler {
             </FileLink>
 
             <div class="footer">
-                <FileLink {file} class="text-primary-500 truncate" on:preview>
-                    {file.name}
-                </FileLink>
-
-                <FileActions {file} on:rename on:download on:delete />
+                {#if renaming === file}
+                    <form on:submit|preventDefault={rename}>
+                        <input class="input thin" type="text" bind:value={renaming.name} use:focus>
+                    </form>
+                {:else}
+                    <FileLink {file} class="text-primary-500 truncate" on:preview>
+                        {file.name}
+                    </FileLink>
+                {/if}
+                <FileActions {file} on:rename={startRenaming} on:download on:delete />
             </div>
         </div>
     {/each}
@@ -77,7 +104,7 @@ function select(file: File): EventHandler {
         .header {
             display: flex;
             flex-direction: row;
-            justify-content: justify-between;
+            justify-content: space-between;
             align-items: center;
             width: 100%;
         }
@@ -85,7 +112,7 @@ function select(file: File): EventHandler {
         .footer {
             display: flex;
             flex-direction: row;
-            justify-content: justify-between;
+            justify-content: space-between;
             align-items: center;
             width: 100%;
             gap: var(--oxi-size-4);

--- a/web/src/lib/paths.ts
+++ b/web/src/lib/paths.ts
@@ -1,0 +1,8 @@
+export function rename(path: string, name: string): string {
+	const segments = path.split("/");
+
+	const oldName = segments.pop();
+	if (!oldName) return path;
+
+	return [...segments, name].join("/");
+}

--- a/web/src/routes/(app)/files/[...path]/+page.svelte
+++ b/web/src/routes/(app)/files/[...path]/+page.svelte
@@ -5,12 +5,12 @@ import { type ErrorResponse, type File, type FileList, client } from "$lib/api";
 import Loading from "$lib/components/Loading.svelte";
 import PageTitle from "$lib/components/PageTitle.svelte";
 import { addToast, reportError } from "$lib/components/Toast.svelte";
+import Fab from "$lib/components/buttons/Fab.svelte";
 import FilePreview from "$lib/components/files/FilePreview.svelte";
 import FilesGrid from "$lib/components/files/FilesGrid.svelte";
 import FilesList from "$lib/components/files/FilesList.svelte";
 import NoFiles from "$lib/components/files/NoFiles.svelte";
-import { faPlus } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/svelte-fontawesome";
+import { faFile, faFolder, faPlus } from "@fortawesome/free-solid-svg-icons";
 import { Localized, localize } from "@nubolab-ffwd/svelte-fluent";
 import { get, writable } from "svelte/store";
 import type { PageData } from "./$types";
@@ -206,6 +206,30 @@ async function handleResponseError(error: ErrorResponse | Response) {
 function togglePreview(preview?: File) {
 	pushState("", { preview });
 }
+
+function createFolder() {
+	const ff: FileList = files ?? {
+		items: [],
+		count: 0,
+		total: 0,
+		next: null,
+	};
+
+	const folder: File = {
+		id: crypto.randomUUID(),
+		type: "folder",
+		contentType: "application/x-folder",
+		path: "/new",
+		name: "New Folder",
+		size: 0,
+	};
+
+	files = {
+		...ff,
+		items: [folder, ...ff.items],
+		count: ff.count + 1,
+	};
+}
 </script>
 
 <div class="action-bar">
@@ -285,18 +309,30 @@ function togglePreview(preview?: File) {
     <FilePreview file={$page.state.preview} on:close={() => togglePreview()} />
 {/if}
 
-<Localized id="files-upload-cta" let:text>
-    <button class="fab primary" on:click={pickFile} title={text}>
-        <FontAwesomeIcon icon={faPlus} />
-        <input
-            data-testid="upload-files"
-            bind:this={uploadInput}
-            type="file"
-            multiple
-            on:change={upload}
-            hidden
+<Localized id="files-fab" let:text let:attrs>
+    <Fab title={text} icon={faPlus} color="primary" multiple>
+        <Fab
+            title={attrs.folder}
+            icon={faFolder}
+            color="secondary"
+            on:click={createFolder}
         />
-    </button>
+        <Fab
+            title={attrs.file}
+            icon={faFile}
+            color="secondary"
+            on:click={pickFile}
+        >
+            <input
+                data-testid="upload-files"
+                bind:this={uploadInput}
+                type="file"
+                multiple
+                on:change={upload}
+                hidden
+            />
+        </Fab>
+    </Fab>
 </Localized>
 
 <style>

--- a/web/src/styles/components/_button.scss
+++ b/web/src/styles/components/_button.scss
@@ -86,24 +86,63 @@
     }
 }
 
-.fab {
+@mixin fab-floating {
     position: fixed;
     z-index: 10;
-    padding: var(--oxi-size-2);
-    margin: var(--oxi-size-8);
     bottom: 0;
     right: 0;
-    border-radius: var(--oxi-rounded-full);
+    margin: var(--oxi-size-8);
     height: 50px;
     width: 50px;
+    aspect-ratio: 1/1;
+}
+
+.fab {
+    @include fab-floating;
+
+    padding: var(--oxi-size-3);
+    border-radius: var(--oxi-rounded-full);
 
     svg {
-        height: 30px;
-        width: 30px;
+        height: 100%;
+        width: 100%;
     }
 
     &.primary {
         background-color: var(--oxi-color-primary-500);
         color: var(--oxi-color-primary-50);
+    }
+
+    &.secondary {
+        background-color: var(--oxi-color-primary-300);
+        color: var(--oxi-color-primary-50);
+    }
+}
+
+.fab-multi {
+    @include fab-floating;
+
+    display: flex;
+    flex-direction: column-reverse;
+    align-content: center;
+    gap: var(--oxi-size-4);
+
+    .fab {
+        position: unset;
+        margin: 0;
+    }
+
+    .fab-children {
+        display: flex;
+        flex-direction: column;
+        align-content: center;
+        gap: var(--oxi-size-4);
+        position: unset !important; // overriding melt-ui
+
+        .fab {
+            height: 45px;
+            width: 45px;
+            align-self: center;
+        }
     }
 }

--- a/web/src/styles/components/_input.scss
+++ b/web/src/styles/components/_input.scss
@@ -18,6 +18,10 @@
             color: var(--oxi-color-danger-500);
         }
     }
+
+    &.thin {
+        padding: var(--oxi-size-1);
+    }
 }
 
 .label {

--- a/web/translations/en/page/files.ftl
+++ b/web/translations/en/page/files.ftl
@@ -39,3 +39,7 @@ files-delete-confirm = Are you sure you want to delete { $file ->
         [selected] all selected files
         *[one] { $file }
     }?
+
+files-fab = Create
+    .file = Upload file
+    .folder = Create folder


### PR DESCRIPTION
This is not a perfect PR, but it's a good start.

Renaming a file simply copies the content to the new path in the blob store, updates the database entry, and then removes the old content. Simple enough.

Renaming a folder is trickier. It requires changing its name and path in the database and recursively updating all children folders and files. This is not simple to do transactionally, so for now, they are just looped over. A future improvement should refactor it in a more event-driven manner, scheduling a background job that updates each child and reports any error to the admin.

Do also note that currently, it is not possible to delete folders, because that would require to also recursively delete each child. A future PR will address that.

Closes #6 

|  |  |  |
|--------|--------|--------|
| ![image](https://github.com/oxidrive/oxidrive/assets/9077612/4141fd9d-4437-497f-bef2-c24fe7f420d3) | ![image](https://github.com/oxidrive/oxidrive/assets/9077612/57c4e3e5-df88-4a4f-a282-ba930cbef07e) | ![image](https://github.com/oxidrive/oxidrive/assets/9077612/b77dcda8-71bc-45da-8ebe-096a38b3b431) | 

